### PR TITLE
Add docutils dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - setuptools
   run:
     - python
+    - docutils >=0.3
 
 test:
   imports:


### PR DESCRIPTION
Adds missing docutils dependency.  (It's not actually used by the module itself, but it's in `install_requires`, so not having it installed causes a silent failure in pytest/pytest-benchmark's plugin loading, which use pkg_resources/setuptools.)